### PR TITLE
ifconfig is not handled properly by grep and sed

### DIFF
--- a/pihole6check
+++ b/pihole6check
@@ -27,7 +27,7 @@
 # set -x
 
 # Check host's current Global IPv6 address
-current_ipv6=$(ifconfig | grep 'Scope:Global' | sed -n '1p' | awk '{print $3}' | awk -F'/' '{print $1}')
+current_ipv6=$(ifconfig | grep 'global' | sed -n '1p' | awk '{print $2}' | awk -F'/' '{print $1}')
 printf "\nCurrent IPv6 address: $current_ipv6\n"
 
 # Check IPv6 address configured in Pi-hole


### PR DESCRIPTION
ifconfig is maybe different on my Raspberry after installing unbound:
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.178.6  netmask 255.255.255.0  broadcast 192.168.178.255
        inet6 fd00::936d:13b4:b529:5378  prefixlen 64  scopeid 0x0'<'global '>'
        inet6 fe80::c2d5:b284:35bd:915a  prefixlen 64  scopeid 0x20<link>
        ether b8:27:eb:36:ff:c7  txqueuelen 1000  (Ethernet)
        RX packets 77835  bytes 40766066 (38.8 MiB)
        RX errors 0  dropped 47  overruns 0  frame 0
        TX packets 83549  bytes 37269794 (35.5 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0